### PR TITLE
add catch NullPointerException

### DIFF
--- a/src/android/fr/drangies/cordova/serial/Serial.java
+++ b/src/android/fr/drangies/cordova/serial/Serial.java
@@ -244,12 +244,7 @@ public class Serial extends CordovaPlugin {
 						if (setDTR) port.setDTR(true);
 						if (setRTS) port.setRTS(true);
 					}
-					catch (IOException  e) {
-						// deal with error
-						Log.d(TAG, e.getMessage());
-						callbackContext.error(e.getMessage());
-					}
-					catch (JSONException e) {
+					catch (IOException | JSONException e) {
 						// deal with error
 						Log.d(TAG, e.getMessage());
 						callbackContext.error(e.getMessage());
@@ -285,7 +280,7 @@ public class Serial extends CordovaPlugin {
 						int result = port.write(buffer, 1000);
 						callbackContext.success(result + " character written.");
 					}
-					catch (IOException e) {
+					catch (IOException | NullPointerException e) {
 						// deal with error
 						Log.d(TAG, e.getMessage());
 						callbackContext.error(e.getMessage());
@@ -314,7 +309,7 @@ public class Serial extends CordovaPlugin {
 						int result = port.write(buffer, 1000);
 						callbackContext.success(result + " bytes written.");
 					}
-					catch (IOException | StringIndexOutOfBoundsException e) {
+					catch (IOException | StringIndexOutOfBoundsException | NullPointerException e) {
 						// deal with error
 						Log.d(TAG, e.getMessage());
 						callbackContext.error(e.getMessage());
@@ -372,7 +367,7 @@ public class Serial extends CordovaPlugin {
 							callbackContext.sendPluginResult(new PluginResult(status, data));
 						}
 					}
-					catch (IOException e) {
+					catch (IOException | NullPointerException e) {
 						// deal with error
 						Log.d(TAG, e.getMessage());
 						callbackContext.error(e.getMessage());
@@ -397,7 +392,7 @@ public class Serial extends CordovaPlugin {
 					port = null;
 					callbackContext.success("Serial port cloesd!");
 				}
-				catch (IOException e) {
+				catch (IOException | NullPointerException e) {
 					// deal with error
 					Log.d(TAG, e.getMessage());
 					callbackContext.error(e.getMessage());
@@ -481,7 +476,7 @@ public class Serial extends CordovaPlugin {
 			if (port != null) {
 				try {
 					port.close();
-				} catch (IOException e) {
+				} catch (IOException | NullPointerException e) {
 					// Ignore
 				}
 				port = null;
@@ -512,7 +507,7 @@ public class Serial extends CordovaPlugin {
 						if (setDTR) port.setDTR(true);
 						if (setRTS) port.setRTS(true);
 					}
-					catch (IOException  e) {
+					catch (IOException e) {
 						// deal with error
 						Log.d(TAG, e.getMessage());
 					}
@@ -540,7 +535,7 @@ public class Serial extends CordovaPlugin {
 			try {
 				port.close();
 			}
-			catch (IOException e) {
+			catch (IOException | NullPointerException e) {
 				Log.d(TAG, e.getMessage());
 			}
 		}


### PR DESCRIPTION
## Bug Details
NullPointerException has occurred.

```
2020-02-09 10:15:14.402 22089-23287/? E/AndroidRuntime: FATAL EXCEPTION: pool-1-thread-6
    Process: com.okhiroyuki.redmobilefire, PID: 22089
    java.lang.NullPointerException: Attempt to invoke virtual method 'int android.hardware.usb.UsbDeviceConnection.bulkTransfer(android.hardware.usb.UsbEndpoint, byte[], int, int)' on a null object reference
        at com.hoho.android.usbserial.driver.CdcAcmSerialDriver$CdcAcmSerialPort.write(CdcAcmSerialDriver.java:230)
        at fr.drangies.cordova.serial.Serial$5.run(Serial.java:314)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
        at java.lang.Thread.run(Thread.java:761)
```

## Proposal Changes
It is necessary to catch NullPointerException due to timing issues other than a null check.
